### PR TITLE
Added namespace to get pods command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The following command will delete our pod running in the message-board namespace
 ```
 kubectl delete pod -l name=message-board -n message-board
 
-kubectl get pods
+kubectl get pods -n message-board
 ```
 
 > Wait for the new container to be started. Note: Kubernetes noticed the missing container, and automatically started another one to reach the desired state. 


### PR DESCRIPTION
The demo doesn't use the default namespace, so no pods show unless specifying the `message-board` namespace. 